### PR TITLE
[Be/feat] add sms api

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     implementation 'io.github.cdimascio:java-dotenv:5.2.2'
     implementation 'org.mindrot:jbcrypt:0.4'
+    implementation 'com.twilio.sdk:twilio:10.0.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/backend/src/main/java/com/fbcq/backend/global/dto/response/CommonResponse.java
+++ b/backend/src/main/java/com/fbcq/backend/global/dto/response/CommonResponse.java
@@ -1,8 +1,16 @@
-package com.fbcq.backend.user.presentation.dto.response;
+package com.fbcq.backend.global.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "공통 응답 포맷")
 public record CommonResponse<T>(
+        @Schema(description = "성공 여부", example = "true")
         boolean success,
+
+        @Schema(description = "메시지", example = "요청 성공")
         String message,
+
+        @Schema(description = "응답 데이터")
         T data
 ) {
     public static <T> CommonResponse<T> success(T data) {

--- a/backend/src/main/java/com/fbcq/backend/global/dto/response/ErrorResponse.java
+++ b/backend/src/main/java/com/fbcq/backend/global/dto/response/ErrorResponse.java
@@ -1,0 +1,45 @@
+package com.fbcq.backend.global.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Schema(description = "에러 응답 포맷")
+public record ErrorResponse(
+        @Schema(description = "에러 코드", example = "A001")
+        String code,
+
+        @Schema(description = "에러 메시지", example = "비밀번호가 일치하지 않습니다.")
+        String message,
+
+        @Schema(description = "요청 경로", example = "/api/user/login")
+        String path,
+
+        @Schema(description = "에러 발생 시각", example = "2025-06-02T13:45:00")
+        LocalDateTime timestamp,
+
+        @Schema(description = "필드 검증 실패 목록", example = "[{\"field\": \"email\", \"reason\": \"이메일 형식이 아닙니다.\"}]")
+        List<FieldError> errors
+) {
+
+    public static ErrorResponse of(String code, String message, String path) {
+        return new ErrorResponse(code, message, path, LocalDateTime.now(), null);
+    }
+
+    public static ErrorResponse of(String code, String message, String path, List<FieldError> errors) {
+        return new ErrorResponse(code, message, path, LocalDateTime.now(), errors);
+    }
+
+    public record FieldError(
+            @Schema(description = "문제 발생 필드", example = "phoneNumber")
+            String field,
+
+            @Schema(description = "사유", example = "형식에 맞지 않습니다.")
+            String reason
+    ) {
+        public static FieldError of(String field, String reason) {
+            return new FieldError(field, reason);
+        }
+    }
+}

--- a/backend/src/main/java/com/fbcq/backend/global/exception/AuthCodeResendNotAllowedException.java
+++ b/backend/src/main/java/com/fbcq/backend/global/exception/AuthCodeResendNotAllowedException.java
@@ -1,0 +1,7 @@
+package com.fbcq.backend.global.exception;
+
+public class AuthCodeResendNotAllowedException extends BusinessException {
+    public AuthCodeResendNotAllowedException() {
+        super(ErrorCode.AUTH_CODE_ALREADY_SENT);
+    }
+}

--- a/backend/src/main/java/com/fbcq/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/fbcq/backend/global/exception/ErrorCode.java
@@ -6,7 +6,8 @@ public enum ErrorCode {
     NICKNAME_DUPLICATED("D001", HttpStatus.BAD_REQUEST, "이미 등록된 닉네임입니다."),
     PHONE_DUPLICATED("D002", HttpStatus.BAD_REQUEST, "이미 등록된 번호입니다."),
     USER_NOT_FOUND("N001", HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
-    INVALID_PASSWORD("A001", HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다.");
+    INVALID_PASSWORD("A001", HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    INVALID_AUTH_CODE("A002", HttpStatus.UNAUTHORIZED, "인증번호가 일치하지 않습니다."); // ✅ 추가
 
     private final String code;
     private final HttpStatus status;

--- a/backend/src/main/java/com/fbcq/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/fbcq/backend/global/exception/ErrorCode.java
@@ -7,7 +7,8 @@ public enum ErrorCode {
     PHONE_DUPLICATED("D002", HttpStatus.BAD_REQUEST, "이미 등록된 번호입니다."),
     USER_NOT_FOUND("N001", HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     INVALID_PASSWORD("A001", HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
-    INVALID_AUTH_CODE("A002", HttpStatus.UNAUTHORIZED, "인증번호가 일치하지 않습니다."); // ✅ 추가
+    INVALID_AUTH_CODE("A002", HttpStatus.UNAUTHORIZED, "인증번호가 일치하지 않습니다."), // ✅ 추가
+    AUTH_CODE_ALREADY_SENT("A003", HttpStatus.TOO_MANY_REQUESTS, "잠시 후 다시 시도해주세요.");
 
     private final String code;
     private final HttpStatus status;

--- a/backend/src/main/java/com/fbcq/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/fbcq/backend/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.fbcq.backend.global.exception;
 
-import com.fbcq.backend.user.presentation.dto.response.CommonResponse;
+import com.fbcq.backend.global.dto.response.CommonResponse;
+// import com.fbcq.backend.global.dto.response.ErrorResponse; // ✅ 향후 확장 시 사용
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -13,32 +14,61 @@ import java.util.List;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    /**
+     * 잘못된 파라미터 등 클라이언트 입력 오류 처리
+     */
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<CommonResponse<Void>> handleIllegalArgument(IllegalArgumentException e) {
-        return ResponseEntity.badRequest().body(CommonResponse.fail(e.getMessage()));
+        return ResponseEntity.badRequest()
+                .body(CommonResponse.fail(e.getMessage()));
+
+        // ✅ 확장 구조 예시
+        // return ResponseEntity.badRequest().body(ErrorResponse.of("INVALID_ARGUMENT", e.getMessage(), request.getRequestURI()));
     }
 
+    /**
+     * 예외 누락 대비 시스템 오류 처리
+     */
     @ExceptionHandler(Exception.class)
     public ResponseEntity<CommonResponse<Void>> handleSystemError(Exception e) {
-        return ResponseEntity.internalServerError().body(CommonResponse.fail("예상치 못한 오류가 발생했습니다."));
+        log.error("System error: {}", e.getMessage(), e);
+        return ResponseEntity.internalServerError()
+                .body(CommonResponse.fail("예상치 못한 오류가 발생했습니다."));
+
+        // return ResponseEntity.internalServerError()
+        //         .body(ErrorResponse.of("INTERNAL_ERROR", "예상치 못한 오류가 발생했습니다.", request.getRequestURI()));
     }
 
+    /**
+     * javax.validation 기반 유효성 실패 대응
+     */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<CommonResponse<Object>> handleValidation(MethodArgumentNotValidException e) {
         List<String> errors = e.getBindingResult().getFieldErrors().stream()
                 .map(error -> String.format("[%s] %s", error.getField(), error.getDefaultMessage()))
                 .toList();
 
-        return ResponseEntity.badRequest().body(CommonResponse.fail("유효성 검사 실패", errors));
+        return ResponseEntity.badRequest()
+                .body(CommonResponse.fail("유효성 검사 실패", errors));
+
+        // List<ErrorResponse.FieldError> errorList = ...
+        // return ResponseEntity.badRequest().body(ErrorResponse.of("VALIDATION_ERROR", "유효성 검사 실패", request.getRequestURI(), errorList));
     }
 
+    /**
+     * 커스텀 비즈니스 예외 처리
+     */
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<CommonResponse<Void>> handleBusinessException(BusinessException e) {
         ErrorCode code = e.getErrorCode();
         log.warn("BusinessException: [{}] {}", code.getCode(), code.getMessage());
+
         return ResponseEntity
                 .status(code.getStatus())
                 .body(CommonResponse.fail(code.getMessage()));
+
+        // return ResponseEntity
+        //         .status(code.getStatus())
+        //         .body(ErrorResponse.of(code.getCode(), code.getMessage(), request.getRequestURI()));
     }
 }
-

--- a/backend/src/main/java/com/fbcq/backend/global/exception/InvalidAuthCodeException.java
+++ b/backend/src/main/java/com/fbcq/backend/global/exception/InvalidAuthCodeException.java
@@ -1,0 +1,7 @@
+package com.fbcq.backend.global.exception;
+
+public class InvalidAuthCodeException extends BusinessException {
+	public InvalidAuthCodeException() {
+		super(ErrorCode.INVALID_AUTH_CODE);
+	}
+}

--- a/backend/src/main/java/com/fbcq/backend/sms/application/SmsClient.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/application/SmsClient.java
@@ -1,0 +1,7 @@
+package com.fbcq.backend.sms.application;
+
+import com.fbcq.backend.sms.domain.SmsMessage;
+
+public interface SmsClient {
+    void send(SmsMessage message);
+}

--- a/backend/src/main/java/com/fbcq/backend/sms/application/SmsSendService.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/application/SmsSendService.java
@@ -1,0 +1,24 @@
+package com.fbcq.backend.sms.application;
+
+// SmsSendService.java
+
+import com.fbcq.backend.sms.domain.AuthCodeStore;
+import com.fbcq.backend.sms.domain.SmsMessage;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SmsSendService {
+    private final AuthCodeGenerator codeGenerator;
+    private final SmsClient smsClient;
+    private final AuthCodeStore authCodeStore;
+
+    private static final int AUTH_CODE_TTL_SECONDS = 300;
+
+    public void sendAuthCode(String phoneNumber) {
+        String code = codeGenerator.generate();
+        SmsMessage message = SmsMessage.authCode(phoneNumber, code);
+
+        smsClient.send(message);
+        authCodeStore.save(phoneNumber, code, AUTH_CODE_TTL_SECONDS);
+    }
+}

--- a/backend/src/main/java/com/fbcq/backend/sms/application/SmsSendService.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/application/SmsSendService.java
@@ -2,6 +2,7 @@ package com.fbcq.backend.sms.application;
 
 // SmsSendService.java
 
+import com.fbcq.backend.sms.domain.AuthCodeGenerator;
 import com.fbcq.backend.sms.domain.AuthCodeStore;
 import com.fbcq.backend.sms.domain.SmsMessage;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/fbcq/backend/sms/application/SmsSendService.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/application/SmsSendService.java
@@ -2,11 +2,14 @@ package com.fbcq.backend.sms.application;
 
 // SmsSendService.java
 
+import com.fbcq.backend.global.exception.AuthCodeResendNotAllowedException;
 import com.fbcq.backend.sms.domain.AuthCodeGenerator;
 import com.fbcq.backend.sms.domain.AuthCodeStore;
 import com.fbcq.backend.sms.domain.SmsMessage;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
+@Service
 @RequiredArgsConstructor
 public class SmsSendService {
     private final AuthCodeGenerator codeGenerator;
@@ -16,6 +19,9 @@ public class SmsSendService {
     private static final int AUTH_CODE_TTL_SECONDS = 300;
 
     public void sendAuthCode(String phoneNumber) {
+        if (authCodeStore.get(phoneNumber).isPresent()) {
+            throw new AuthCodeResendNotAllowedException(); // 3분 내 재전송 불가
+        }
         String code = codeGenerator.generate();
         SmsMessage message = SmsMessage.authCode(phoneNumber, code);
 

--- a/backend/src/main/java/com/fbcq/backend/sms/application/SmsVerifyService.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/application/SmsVerifyService.java
@@ -1,5 +1,6 @@
 package com.fbcq.backend.sms.application;
 
+import com.fbcq.backend.global.exception.InvalidAuthCodeException;
 import com.fbcq.backend.sms.domain.AuthCodeStore;
 import lombok.RequiredArgsConstructor;
 

--- a/backend/src/main/java/com/fbcq/backend/sms/application/SmsVerifyService.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/application/SmsVerifyService.java
@@ -3,14 +3,17 @@ package com.fbcq.backend.sms.application;
 import com.fbcq.backend.global.exception.InvalidAuthCodeException;
 import com.fbcq.backend.sms.domain.AuthCodeStore;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
+@Service
 @RequiredArgsConstructor
 public class SmsVerifyService {
     private final AuthCodeStore authCodeStore;
 
     public void verify(String phoneNumber, String inputCode) {
-        String saved = authCodeStore.get(phoneNumber);
-        if (saved == null || !saved.equals(inputCode)) {
+        String saved = authCodeStore.get(phoneNumber)
+                .orElseThrow(InvalidAuthCodeException::new);
+        if (!saved.equals(inputCode)) {
             throw new InvalidAuthCodeException();
         }
 

--- a/backend/src/main/java/com/fbcq/backend/sms/application/SmsVerifyService.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/application/SmsVerifyService.java
@@ -1,0 +1,19 @@
+package com.fbcq.backend.sms.application;
+
+import com.fbcq.backend.sms.domain.AuthCodeStore;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class SmsVerifyService {
+    private final AuthCodeStore authCodeStore;
+
+    public void verify(String phoneNumber, String inputCode) {
+        String saved = authCodeStore.get(phoneNumber);
+        if (saved == null || !saved.equals(inputCode)) {
+            throw new InvalidAuthCodeException();
+        }
+
+        authCodeStore.remove(phoneNumber); // 일회성으로 사용 후 삭제
+    }
+}
+

--- a/backend/src/main/java/com/fbcq/backend/sms/domain/AuthCodeGenerator.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/domain/AuthCodeGenerator.java
@@ -1,0 +1,16 @@
+package com.fbcq.backend.sms.domain;
+
+import java.security.SecureRandom;
+
+public class AuthCodeGenerator {
+    private static final SecureRandom random = new SecureRandom();
+    private static final int CODE_LENGTH = 6;
+
+    public String generate() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < CODE_LENGTH; i++) {
+            sb.append(random.nextInt(10)); // 0 ~ 9
+        }
+        return sb.toString();
+    }
+}

--- a/backend/src/main/java/com/fbcq/backend/sms/domain/AuthCodeGenerator.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/domain/AuthCodeGenerator.java
@@ -1,7 +1,10 @@
 package com.fbcq.backend.sms.domain;
 
+import org.springframework.stereotype.Component;
+
 import java.security.SecureRandom;
 
+@Component
 public class AuthCodeGenerator {
     private static final SecureRandom random = new SecureRandom();
     private static final int CODE_LENGTH = 6;

--- a/backend/src/main/java/com/fbcq/backend/sms/domain/AuthCodeStore.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/domain/AuthCodeStore.java
@@ -1,7 +1,9 @@
 package com.fbcq.backend.sms.domain;
 
+import java.util.Optional;
+
 public interface AuthCodeStore {
     void save(String phoneNumber, String code, int ttlSeconds);  // 인증번호 저장
-    String get(String phoneNumber);                              // 인증번호 조회
+    Optional<String> get(String phoneNumber);                              // 인증번호 조회
     void remove(String phoneNumber);                             // 인증번호 사용 후 삭제
 }

--- a/backend/src/main/java/com/fbcq/backend/sms/domain/AuthCodeStore.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/domain/AuthCodeStore.java
@@ -1,0 +1,7 @@
+package com.fbcq.backend.sms.domain;
+
+public interface AuthCodeStore {
+    void save(String phoneNumber, String code, int ttlSeconds);  // 인증번호 저장
+    String get(String phoneNumber);                              // 인증번호 조회
+    void remove(String phoneNumber);                             // 인증번호 사용 후 삭제
+}

--- a/backend/src/main/java/com/fbcq/backend/sms/domain/SmsMessage.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/domain/SmsMessage.java
@@ -3,7 +3,7 @@ package com.fbcq.backend.sms.domain;
 public record SmsMessage(String to, String content) {
 
     public static SmsMessage authCode(String phoneNumber, String code) {
-        String content = "인증번호 [" + code + "]를 입력해주세요.\nCook Share";
+        String content = "인증번호 [" + code + "]를 입력해주세요. <Cook Share>";
         return new SmsMessage(phoneNumber, content);
     }
 }

--- a/backend/src/main/java/com/fbcq/backend/sms/domain/SmsMessage.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/domain/SmsMessage.java
@@ -1,0 +1,10 @@
+package com.fbcq.backend.sms.domain;
+
+public record SmsMessage(String to, String content) {
+
+    public static SmsMessage authCode(String phoneNumber, String code) {
+        String content = "인증번호 [" + code + "]를 입력해주세요.\nCook Share";
+        return new SmsMessage(phoneNumber, content);
+    }
+}
+

--- a/backend/src/main/java/com/fbcq/backend/sms/infrastructure/InMemoryAuthCodeStore.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/infrastructure/InMemoryAuthCodeStore.java
@@ -4,6 +4,7 @@ import com.fbcq.backend.sms.domain.AuthCodeStore;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
@@ -16,10 +17,12 @@ public class InMemoryAuthCodeStore implements AuthCodeStore {
     }
 
     @Override
-    public String get(String phone) {
+    public Optional<String> get(String phone) {
         TimedCode timed = store.get(phone);
-        if (timed == null || timed.expired()) return null;
-        return timed.code();
+        if (timed == null || timed.expired()) {
+            return Optional.empty();  // ✅ null 반환 금지
+        }
+        return Optional.of(timed.code());
     }
 
     @Override

--- a/backend/src/main/java/com/fbcq/backend/sms/infrastructure/InMemoryAuthCodeStore.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/infrastructure/InMemoryAuthCodeStore.java
@@ -1,0 +1,36 @@
+package com.fbcq.backend.sms.infrastructure;
+
+import com.fbcq.backend.sms.domain.AuthCodeStore;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class InMemoryAuthCodeStore implements AuthCodeStore {
+    private final Map<String, TimedCode> store = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(String phone, String code, int ttlSeconds) {
+        store.put(phone, new TimedCode(code, System.currentTimeMillis() + ttlSeconds * 1000));
+    }
+
+    @Override
+    public String get(String phone) {
+        TimedCode timed = store.get(phone);
+        if (timed == null || timed.expired()) return null;
+        return timed.code();
+    }
+
+    @Override
+    public void remove(String phone) {
+        store.remove(phone);
+    }
+
+    private record TimedCode(String code, long expiresAt) {
+        boolean expired() {
+            return System.currentTimeMillis() > expiresAt;
+        }
+    }
+}
+

--- a/backend/src/main/java/com/fbcq/backend/sms/infrastructure/PhoneNumberUtil.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/infrastructure/PhoneNumberUtil.java
@@ -1,0 +1,12 @@
+package com.fbcq.backend.sms.infrastructure;
+
+public class PhoneNumberUtil {
+    public static String toE164Format(String rawNumber) {
+        // 01012345678 -> +821012345678
+        if (rawNumber.startsWith("0")) {
+            return "+82" + rawNumber.substring(1);
+        }
+        // 이미 +로 시작하면 그대로 사용
+        return rawNumber;
+    }
+}

--- a/backend/src/main/java/com/fbcq/backend/sms/infrastructure/TwilioSmsClient.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/infrastructure/TwilioSmsClient.java
@@ -1,0 +1,37 @@
+package com.fbcq.backend.sms.infrastructure;
+
+import com.fbcq.backend.sms.application.SmsClient;
+import com.fbcq.backend.sms.domain.SmsMessage;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TwilioSmsClient implements SmsClient {
+
+    @Value("${TWILIO_ACCOUNT_SID}")
+    private String accountSid;
+
+    @Value("${TWILIO_AUTH_TOKEN}")
+    private String authToken;
+
+    @Value("${TWILIO_SENDER_PHONE}")
+    private String senderPhone;
+
+    @PostConstruct
+    public void init() {
+        Twilio.init(accountSid, authToken);
+    }
+
+    @Override
+    public void send(SmsMessage message) {
+        Message.creator(
+                new PhoneNumber(message.to()),
+                new PhoneNumber(senderPhone),
+                message.content()
+        ).create();
+    }
+}
+

--- a/backend/src/main/java/com/fbcq/backend/sms/infrastructure/TwilioSmsClient.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/infrastructure/TwilioSmsClient.java
@@ -14,13 +14,13 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class TwilioSmsClient implements SmsClient {
 
-    @Value("${TWILIO_ACCOUNT_SID}")
+    @Value("${twilio.account-sid}")
     private String accountSid;
 
-    @Value("${TWILIO_AUTH_TOKEN}")
+    @Value("${twilio.auth-token}")
     private String authToken;
 
-    @Value("${TWILIO_SENDER_PHONE}")
+    @Value("${twilio.sender-phone}")
     private String senderPhone;
 
     @PostConstruct
@@ -30,8 +30,14 @@ public class TwilioSmsClient implements SmsClient {
 
     @Override
     public void send(SmsMessage message) {
+        String to = PhoneNumberUtil.toE164Format(message.to());
+
+        if (to.equals(senderPhone)) {
+            throw new IllegalArgumentException("수신 번호와 발신 번호가 동일할 수 없습니다.");
+        }
+
         Message.creator(
-                new PhoneNumber(message.to()),
+                new PhoneNumber(to),
                 new PhoneNumber(senderPhone),
                 message.content()
         ).create();

--- a/backend/src/main/java/com/fbcq/backend/sms/infrastructure/TwilioSmsClient.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/infrastructure/TwilioSmsClient.java
@@ -2,6 +2,9 @@ package com.fbcq.backend.sms.infrastructure;
 
 import com.fbcq.backend.sms.application.SmsClient;
 import com.fbcq.backend.sms.domain.SmsMessage;
+import com.twilio.rest.api.v2010.account.Message;
+import com.twilio.type.PhoneNumber;
+import com.twilio.Twilio;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/backend/src/main/java/com/fbcq/backend/sms/presentation/SmsController.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/presentation/SmsController.java
@@ -1,0 +1,4 @@
+package com.fbcq.backend.sms.presentation;
+
+public class SmsController {
+}

--- a/backend/src/main/java/com/fbcq/backend/sms/presentation/SmsController.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/presentation/SmsController.java
@@ -1,4 +1,0 @@
-package com.fbcq.backend.sms.presentation;
-
-public class SmsController {
-}

--- a/backend/src/main/java/com/fbcq/backend/sms/presentation/dto/SmsVerifyRequest.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/presentation/dto/SmsVerifyRequest.java
@@ -1,0 +1,15 @@
+package com.fbcq.backend.sms.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+
+public record SmsVerifyRequest(
+        @Schema(description = "전화번호", example = "01012345678")
+        @Pattern(regexp = "^01[0-9]{8,9}$", message = "유효한 전화번호 형식이어야 합니다.")
+        String phoneNumber,
+
+        @Schema(description = "인증번호", example = "123456")
+        @Pattern(regexp = "^[0-9]{6}$", message = "6자리 숫자여야 합니다.")
+        String authCode
+) {}
+

--- a/backend/src/main/java/com/fbcq/backend/sms/presentation/web/SmsController.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/presentation/web/SmsController.java
@@ -1,0 +1,40 @@
+package com.fbcq.backend.sms.presentation;
+
+import com.fbcq.backend.sms.application.SmsSendService;
+import com.fbcq.backend.sms.application.SmsVerifyService;
+import com.fbcq.backend.user.presentation.dto.response.CommonResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/sms")
+@RequiredArgsConstructor
+public class SmsController {
+    private final SmsSendService smsSendService;
+    private final SmsVerifyService smsVerifyService;
+
+    /*
+     * 인증번호 전송
+     */
+    @PostMapping("/phone")
+    public ResponseEntity<CommonResponse<String>> sendAuthCode(@RequestParam String phoneNumber) {
+        smsSendService.sendAuthCode(phoneNumber);
+        return ResponseEntity.ok(CommonResponse.success(null, "인증번호가 전송되었습니다."));
+    }
+
+    /*
+     * 인증번호 검증
+     */
+    @PostMapping("/verify")
+    public ResponseEntity<CommonResponse<String>> verifyAuthCode(
+            @RequestParam String phoneNumber,
+            @RequestParam String authCode
+    ) {
+        smsVerifyService.verify(phoneNumber, authCode);
+        return ResponseEntity.ok(CommonResponse.success(null, "인증이 완료되었습니다."));
+    }
+}

--- a/backend/src/main/java/com/fbcq/backend/sms/presentation/web/SmsController.java
+++ b/backend/src/main/java/com/fbcq/backend/sms/presentation/web/SmsController.java
@@ -1,15 +1,24 @@
-package com.fbcq.backend.sms.presentation;
+package com.fbcq.backend.sms.presentation.web;
 
 import com.fbcq.backend.sms.application.SmsSendService;
 import com.fbcq.backend.sms.application.SmsVerifyService;
-import com.fbcq.backend.user.presentation.dto.response.CommonResponse;
+import com.fbcq.backend.sms.presentation.dto.SmsVerifyRequest;
+import com.fbcq.backend.global.dto.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Sms", description = "인증 관련 API")
+@Validated
 @RestController
 @RequestMapping("api/sms")
 @RequiredArgsConstructor
@@ -20,8 +29,19 @@ public class SmsController {
     /*
      * 인증번호 전송
      */
+    @Operation(summary = "인증번호 전송")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증번호 전송 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "이미 가입된 번호 or 형식 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "429", description = "재요청 제한 (3분 내 중복 요청)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
     @PostMapping("/phone")
-    public ResponseEntity<CommonResponse<String>> sendAuthCode(@RequestParam String phoneNumber) {
+    public ResponseEntity<CommonResponse<String>> sendAuthCode(@RequestParam
+        @Pattern(regexp = "^01[0-9]{8,9}$", message = "유효한 전화번호 형식이어야 합니다.")
+        String phoneNumber) {
         smsSendService.sendAuthCode(phoneNumber);
         return ResponseEntity.ok(CommonResponse.success(null, "인증번호가 전송되었습니다."));
     }
@@ -29,12 +49,18 @@ public class SmsController {
     /*
      * 인증번호 검증
      */
+    @Operation(summary = "인증번호 확인")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "인증번호 인증 성공",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 인증번호 or 형식 오류",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class))),
+            @ApiResponse(responseCode = "429", description = "재요청 제한 (3분 내 중복 요청)",
+                    content = @Content(schema = @Schema(implementation = CommonResponse.class)))
+    })
     @PostMapping("/verify")
-    public ResponseEntity<CommonResponse<String>> verifyAuthCode(
-            @RequestParam String phoneNumber,
-            @RequestParam String authCode
-    ) {
-        smsVerifyService.verify(phoneNumber, authCode);
+    public ResponseEntity<CommonResponse<String>> verifyAuthCode(@Valid @RequestBody SmsVerifyRequest request) {
+        smsVerifyService.verify(request.phoneNumber(), request.authCode());
         return ResponseEntity.ok(CommonResponse.success(null, "인증이 완료되었습니다."));
     }
 }

--- a/backend/src/main/java/com/fbcq/backend/user/presentation/web/UserController.java
+++ b/backend/src/main/java/com/fbcq/backend/user/presentation/web/UserController.java
@@ -5,7 +5,7 @@ import com.fbcq.backend.user.application.command.SignUpCommand;
 import com.fbcq.backend.user.application.command.UserCommandService;
 import com.fbcq.backend.user.presentation.dto.request.LoginRequest;
 import com.fbcq.backend.user.presentation.dto.request.SignUpRequest;
-import com.fbcq.backend.user.presentation.dto.response.CommonResponse;
+import com.fbcq.backend.global.dto.response.CommonResponse;
 import com.fbcq.backend.user.presentation.dto.response.UserResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;

--- a/backend/src/main/resources/application-sms.properties
+++ b/backend/src/main/resources/application-sms.properties
@@ -1,0 +1,3 @@
+twilio.account-sid=${TWILIO_ACCOUNT_SID}
+twilio.auth-token=${TWILIO_AUTH_TOKEN}
+twilio.sender-phone=${TWILIO_SENDER_PHONE}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -17,4 +17,4 @@ spring.jpa.properties.hibernate.format_sql=true
 # ???? ???? (dev, prod ?)
 spring.profiles.active=dev
 # ??? ??? ???? (application-swagger.properties)
-spring.profiles.include=swagger
+spring.profiles.include=swagger, sms


### PR DESCRIPTION
<!-- PR 제목은 다음을 참고해서 작성해주세요.
예시: [fe/feat] add login ui component
-->

## 🔎 변경 사항
<!-- 어떤 작업을 했는지 핵심 내용을 간단히 적어주세요. -->
- Twilio API 연동
- sendAuthCode API 개발
- verifyAuthCode API 개발
- 미리 Twillio API에 등록된 번호만 이용 가능
- 문자는 차단 메시지로 옴... 
- 문자 폼 형식 글자 깨짐 현상 발생 -> 수정 필요

## 🖼️ 이미지 첨부 (선택)
<!-- 변경된 UI가 있다면 이미지로 첨부해주세요. -->
<!-- 예: <img src="파일주소" width="40%" /> -->
![image](https://github.com/user-attachments/assets/59a6d453-04a9-48e0-9c44-215e750337d3)
![image](https://github.com/user-attachments/assets/f1031dac-19ff-469a-b2a5-eb92066babc5)
![image](https://github.com/user-attachments/assets/292cf88b-d283-40ea-97c4-bf9dfba55ede)


## 🛠️ 의존성 변경
<!-- 새로 추가한 라이브러리나 설정이 있다면 작성해주세요. 없으면 N/A -->
- implementation 'com.twilio.sdk:twilio:10.0.0'
- application-sms.properties